### PR TITLE
v2.3

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,17 @@
 # Release Notes
 
 
+## v2.3 (2022-03-26)
+
+### BREAKING CHANGES
+
+* Renamed `SonyCledis2D3DMode.Select2D` to `Mode2D`. Ditto for `Select3D`.
+
+### Fixes
+
+* Fixed an issue where commands had an extra `\r` character that caused them to fail.
+
+
 ## v2.2 (2022-03-25)
 
 ### Features

--- a/Source/RadiantPi.Sony.Cledis/ASonyCledisClient.cs
+++ b/Source/RadiantPi.Sony.Cledis/ASonyCledisClient.cs
@@ -18,7 +18,6 @@
 
 namespace RadiantPi.Sony.Cledis;
 
-using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;

--- a/Source/RadiantPi.Sony.Cledis/ISonyCledis.cs
+++ b/Source/RadiantPi.Sony.Cledis/ISonyCledis.cs
@@ -65,8 +65,8 @@ public enum SonyCledisDualDisplayPort3D4KMode {
 
 public enum SonyCledis2D3DMode {
     Undefined,
-    Select2D,
-    Select3D
+    Mode2D,
+    Mode3D
 }
 
 public enum SonyCledis3DFormat {

--- a/Source/RadiantPi.Sony.Cledis/Mock/SonyCledisMockClient.cs
+++ b/Source/RadiantPi.Sony.Cledis/Mock/SonyCledisMockClient.cs
@@ -34,7 +34,7 @@ public class SonyCledisMockClient : ASonyCledisClient {
     private SonyCledisPictureMode _mode = SonyCledisPictureMode.Mode1;
     private SonyCledisDualDisplayPort3D4KMode _3d4kStatus = SonyCledisDualDisplayPort3D4KMode.On;
     private SonyCledisFanMode _fanMode = SonyCledisFanMode.Mid;
-    private SonyCledis2D3DMode _2d3dSelection = SonyCledis2D3DMode.Select2D;
+    private SonyCledis2D3DMode _2d3dmode = SonyCledis2D3DMode.Mode2D;
     private SonyCledis3DFormat _3dFormat = SonyCledis3DFormat.FrameSequential;
     private Dictionary<SonyCledisInput, int> _verticalPictureShift = new Dictionary<SonyCledisInput, int>();
     private Dictionary<SonyCledisInput, int> _horizontalPictureShift = new Dictionary<SonyCledisInput, int>();
@@ -85,10 +85,10 @@ public class SonyCledisMockClient : ASonyCledisClient {
     }
 
     public override Task<SonyCledis2D3DMode> Get2D3DModeAsync()
-        => Task.FromResult(_2d3dSelection);
+        => Task.FromResult(_2d3dmode);
 
     public override Task Set2D3DModeAsync(SonyCledis2D3DMode mode) {
-        _2d3dSelection = mode;
+        _2d3dmode = mode;
         return Task.CompletedTask;
     }
 

--- a/Source/RadiantPi.Sony.Cledis/RadiantPi.Sony.Cledis.csproj
+++ b/Source/RadiantPi.Sony.Cledis/RadiantPi.Sony.Cledis.csproj
@@ -4,10 +4,11 @@
     <RootNamespace>RadiantPi.Sony.Cledis</RootNamespace>
     <NoWarn>CS1998</NoWarn>
     <Deterministic>true</Deterministic>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
     <PackageId>RadiantPi.Sony.Cledis</PackageId>
-    <Version>2.2</Version>
+    <Version>2.3</Version>
     <Title>RadiantPi Sony C-LED (Cledis) Client Library</Title>
     <Description>Communication client for Sony C-LED (Cledis)</Description>
     <Copyright>Copyright (C) 2020-2022</Copyright>
@@ -18,12 +19,6 @@
     <PackageTags>Sony;CLEDIS;Crystal-LED</PackageTags>
     <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
   </PropertyGroup>
-  <ItemGroup>
-    <Using Include="System" />
-    <Using Include="System.Linq" />
-    <Using Include="System.Threading" />
-    <Using Include="System.Threading.Tasks" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="RadiantPi.Telnet" Version="2.2" />

--- a/Source/RadiantPi.Sony.Cledis/SonyCledisClient.cs
+++ b/Source/RadiantPi.Sony.Cledis/SonyCledisClient.cs
@@ -18,7 +18,6 @@
 
 namespace RadiantPi.Sony.Cledis;
 
-using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
@@ -141,15 +140,15 @@ public class SonyCledisClient : ASonyCledisClient {
 
     public override Task<SonyCledis2D3DMode> Get2D3DModeAsync()
         => LogRequestResponse(async () => ConvertResponse<string>(await SendAsync("2d3d_sel ?")) switch {
-            "2d" => SonyCledis2D3DMode.Select2D,
-            "3d" => SonyCledis2D3DMode.Select3D,
+            "2d" => SonyCledis2D3DMode.Mode2D,
+            "3d" => SonyCledis2D3DMode.Mode3D,
             var value => throw new SonyCledisUnrecognizedResponseException(value)
         });
 
     public override Task Set2D3DModeAsync(SonyCledis2D3DMode mode)
         => mode switch {
-            SonyCledis2D3DMode.Select2D => LogRequest(() => SendCommandAsync("2d3d_sel \"2d\""), mode),
-            SonyCledis2D3DMode.Select3D => LogRequest(() => SendCommandAsync("2d3d_sel \"3d\""), mode),
+            SonyCledis2D3DMode.Mode2D => LogRequest(() => SendCommandAsync("2d3d_sel \"2d\""), mode),
+            SonyCledis2D3DMode.Mode3D => LogRequest(() => SendCommandAsync("2d3d_sel \"3d\""), mode),
             _ => throw new ArgumentException("invalid value", nameof(mode))
         };
 
@@ -240,7 +239,7 @@ public class SonyCledisClient : ASonyCledisClient {
     }
 
     private async Task SendCommandAsync(string message)
-        => ValidateResponse(await SendAsync(message + "\r").ConfigureAwait(false));
+        => ValidateResponse(await SendAsync(message).ConfigureAwait(false));
 
     private async Task<string> SendAsync(string message) {
         if(!_telnet.Connected) {


### PR DESCRIPTION
### BREAKING CHANGES

* Renamed `SonyCledis2D3DMode.Select2D` to `Mode2D`. Ditto for `Select3D`.

### Fixes

* Fixed an issue where commands had an extra `\r` character that caused them to fail.