### PR TITLE
v2.4

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,17 @@
 # Release Notes
 
 
+## v2.4 (2022-03-26)
+
+### BREAKING CHANGES
+
+* Removed `Id` property in `SonyCledisModuleTemperature` as it was never set.
+
+### Fixes
+
+* Fixed an issue with serializing the Sony C-LED temperatures data structure during trace logging.
+
+
 ## v2.3 (2022-03-26)
 
 ### BREAKING CHANGES

--- a/Source/RadiantPi.Sony.Cledis/ASonyCledisClient.cs
+++ b/Source/RadiantPi.Sony.Cledis/ASonyCledisClient.cs
@@ -25,11 +25,36 @@ using RadiantPi.Sony.Cledis.Exceptions;
 
 public abstract class ASonyCledisClient : ISonyCledis {
 
+    //--- Types ---
+    protected class SonyCledisModuleTemperatureArrayConverter : JsonConverter<SonyCledisModuleTemperature[,]> {
+
+        //--- Methods ---
+        public override SonyCledisModuleTemperature[,]? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => throw new NotImplementedException();
+
+        public override void Write(Utf8JsonWriter writer, SonyCledisModuleTemperature[,] value, JsonSerializerOptions options) {
+            var converter = (JsonConverter<SonyCledisModuleTemperature>)options.GetConverter(typeof(SonyCledisModuleTemperature));
+            writer.WriteStartArray();
+            for(var rowIndex = 0; rowIndex < value.GetLength(1); ++rowIndex) {
+                for(var columnIndex = 0; columnIndex < value.GetLength(0); ++columnIndex) {
+                    writer.WriteStartObject();
+                    writer.WriteNumber("Row", rowIndex);
+                    writer.WriteNumber("Column", columnIndex);
+                    writer.WritePropertyName("Module");
+                    converter.Write(writer, value[columnIndex, rowIndex], options);
+                    writer.WriteEndObject();
+                }
+            }
+            writer.WriteEndArray();
+        }
+    }
+
     //--- Class Fields ---
     protected static readonly JsonSerializerOptions g_jsonSerializerOptions = new() {
         WriteIndented = true,
         Converters = {
-            new JsonStringEnumConverter()
+            new JsonStringEnumConverter(),
+            new SonyCledisModuleTemperatureArrayConverter()
         }
     };
 

--- a/Source/RadiantPi.Sony.Cledis/ISonyCledis.cs
+++ b/Source/RadiantPi.Sony.Cledis/ISonyCledis.cs
@@ -94,7 +94,6 @@ public class SonyCledisTemperatures {
 public class SonyCledisModuleTemperature {
 
     //--- Properties ---
-    public string? Id { get; set; }
     public int Row { get; set; }
     public int Column { get; set; }
     public float AmbientTemperature { get; set; }

--- a/Source/RadiantPi.Sony.Cledis/RadiantPi.Sony.Cledis.csproj
+++ b/Source/RadiantPi.Sony.Cledis/RadiantPi.Sony.Cledis.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
 
     <PackageId>RadiantPi.Sony.Cledis</PackageId>
-    <Version>2.3</Version>
+    <Version>2.4</Version>
     <Title>RadiantPi Sony C-LED (Cledis) Client Library</Title>
     <Description>Communication client for Sony C-LED (Cledis)</Description>
     <Copyright>Copyright (C) 2020-2022</Copyright>


### PR DESCRIPTION
### BREAKING CHANGES

* Removed `Id` property in `SonyCledisModuleTemperature` as it was never set.

### Fixes

* Fixed an issue with serializing the Sony C-LED temperatures data structure during trace logging.
